### PR TITLE
Adjust rdstation needs

### DIFF
--- a/lib/spf/query/query.rb
+++ b/lib/spf/query/query.rb
@@ -27,7 +27,7 @@ module SPF
       end
 
       # check for SPF in the TXT records
-      ["_spf.#{domain}", domain].each do |host|
+      [domain, "_spf.#{domain}"].each do |host|
         begin
           records = resolver.getresources(host, Resolv::DNS::Resource::IN::TXT)
 

--- a/lib/spf/query/version.rb
+++ b/lib/spf/query/version.rb
@@ -1,5 +1,5 @@
 module SPF
   module Query
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -14,8 +14,8 @@ describe SPF::Query do
     context "when _spf.domain.com exists" do
       let(:domain) { 'google.com' }
 
-      it "should return the first SPF record" do
-        expect(subject.query(domain)).to be == %{v=spf1 include:_netblocks.google.com include:_netblocks2.google.com include:_netblocks3.google.com ~all}
+      it "should return the queried domain SPF record first instead of _spf.domain" do
+        expect(subject.query(domain)).to be == %{v=spf1 include:_spf.google.com ~all}
       end
     end
 

--- a/spf-query.gemspec
+++ b/spf-query.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "parslet", "~> 1.0"
 
+  gem.add_development_dependency "byebug"
   gem.add_development_dependency "bundler", "~> 1.6"
   gem.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Ajusta a busca de SPF para as necessidades da RD.
## O que acontecia

Um domínio que possuía um DNS record _spf.domain.com e estivesse configurado erroneamente fazia com que a checagem no RD Station falhasse. Isso porque ele buscava primeiro nesse record e retornava o valor caso encontrasse. 

Para a RD instruímos ao usuário configurar o TXT record do domain.com dele, sendo assim deve ser ele que precisamos verificar primeiro e só se não existir, buscar no _spf.domain.com.
### Antes

SPF::Query.query('superlogica.com')

`"v=spf1 include:spf.mandrillapp.com ?all"`
### Depois

SPF::Query.query('superlogica.com')

`"v=spf1 a mx include:_spf.google.com include:_spf.rdstation.com.br include:spf.mandrillapp.com ~all"`
