### PR TITLE
Recursive search on include

### DIFF
--- a/lib/spf/query/query.rb
+++ b/lib/spf/query/query.rb
@@ -27,7 +27,7 @@ module SPF
       end
 
       # check for SPF in the TXT records
-      ["_spf.#{domain}", domain].each do |host|
+      [domain, "_spf.#{domain}"].each do |host|
         begin
           records = resolver.getresources(host, Resolv::DNS::Resource::IN::TXT)
 

--- a/lib/spf/query/query.rb
+++ b/lib/spf/query/query.rb
@@ -1,6 +1,6 @@
 require 'resolv'
 require 'resolv/dns/resource/in/spf'
-require 'byebug'
+
 module SPF
   module Query
     #
@@ -29,24 +29,19 @@ module SPF
       rescue Resolv::ResolvError
       end
 
-      query_result = process_domains(["_spf.#{domain}", domain], resolver)
-      return nil if query_result[:text].empty?
+      domains = ["_spf.#{domain}", domain]
+      return_text = ''
 
-      return_text = query_result[:text]
-      additional_domains = query_result[:included]
-
-      if additional_domains
-        i = 1
-        while i < max_lookups
-          additional_result = process_domains(additional_domains, resolver)
-          break unless additional_result
-          return_text << additional_result[:text]
-          additional_domains = additional_result[:included]
-          i += 1
-        end
+      for i in 1..max_lookups
+        result = process_domains(domains, resolver)
+        break if result[:text].empty?
+        return_text << result[:text]
+        domains = result[:included]
       end
 
-      return return_text.split(' ').uniq.join(' ')
+      return nil if return_text.empty?
+
+      return_text.split(' ').uniq.join(' ')
     end
 
     def self.process_domains(domains, resolver)

--- a/lib/spf/query/query.rb
+++ b/lib/spf/query/query.rb
@@ -29,7 +29,7 @@ module SPF
       rescue Resolv::ResolvError
       end
 
-      query_result = process_domains([domain, "_spf.#{domain}"], resolver)
+      query_result = process_domains(["_spf.#{domain}", domain], resolver)
       return nil unless query_result
 
       return_text = query_result[:text]

--- a/lib/spf/query/version.rb
+++ b/lib/spf/query/version.rb
@@ -1,5 +1,5 @@
 module SPF
   module Query
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -34,5 +34,15 @@ describe SPF::Query do
         expect(subject.query(domain)).to be_nil
       end
     end
+
+    context "when max_lookups is greater than 1" do
+      let(:domain) { 'google.com' }
+
+      subject { SPF::Query.query(domain, Resolv::DNS.new, 2) }
+
+      it "should return recursively by the value set" do
+        is_expected.to be == %{v=spf1 include:_spf.google.com ~all include:_netblocks.google.com include:_netblocks2.google.com include:_netblocks3.google.com}
+      end
+    end
   end
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -14,8 +14,8 @@ describe SPF::Query do
     context "when _spf.domain.com exists" do
       let(:domain) { 'google.com' }
 
-      it "should return the queried domain SPF record first instead of _spf.domain" do
-        expect(subject.query(domain)).to be == %{v=spf1 include:_spf.google.com ~all}
+      it "should return _spf.domain and domain.com results" do
+        expect(subject.query(domain)).to be == %{v=spf1 include:_netblocks.google.com include:_netblocks2.google.com include:_netblocks3.google.com ~all include:_spf.google.com}
       end
     end
 
@@ -41,7 +41,13 @@ describe SPF::Query do
       subject { SPF::Query.query(domain, Resolv::DNS.new, 2) }
 
       it "should return recursively by the value set" do
-        is_expected.to be == %{v=spf1 include:_spf.google.com ~all include:_netblocks.google.com include:_netblocks2.google.com include:_netblocks3.google.com}
+        expected_result = %w{v=spf1 include:_netblocks.google.com include:_netblocks2.google.com
+          include:_netblocks3.google.com ~all include:_spf.google.com ip4:64.18.0.0/20 ip4:64.233.160.0/19 ip4:66.102.0.0/20
+          ip4:66.249.80.0/20 ip4:72.14.192.0/18 ip4:74.125.0.0/16 ip4:173.194.0.0/16 ip4:207.126.144.0/20 ip4:209.85.128.0/17
+          ip4:216.58.192.0/19 ip4:216.239.32.0/19 ip6:2001:4860:4000::/36 ip6:2404:6800:4000::/36 ip6:2607:f8b0:4000::/36
+          ip6:2800:3f0:4000::/36 ip6:2a00:1450:4000::/36 ip6:2c0f:fb50:4000::/36}
+
+        is_expected.to be == expected_result.join(' ')
       end
     end
   end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -14,8 +14,8 @@ describe SPF::Query do
     context "when _spf.domain.com exists" do
       let(:domain) { 'google.com' }
 
-      it "should return the first SPF record" do
-        expect(subject.query(domain)).to be == %{v=spf1 include:_netblocks.google.com include:_netblocks2.google.com include:_netblocks3.google.com ~all}
+      it "should return the queried domain SPF record first instead of _spf.domain" do
+        expect(subject.query(domain)).to be == %{v=spf1 include:_spf.google.com ~all}
       end
     end
 

--- a/spf-query.gemspec
+++ b/spf-query.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "parslet", "~> 1.0"
 
+  gem.add_development_dependency "byebug"
   gem.add_development_dependency "bundler", "~> 1.6"
   gem.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Adicionar recursão nos includes do registro SPF.
### Como ficou

SPF::Query.query('rdstation.com.br', Resolv::DNS.new)
`=> "v=spf1 a mx include:_spf.google.com include:sendgrid.net include:mail.zendesk.com ~all"`

SPF::Query.query('rdstation.com.br', Resolv::DNS.new, 2)
`=> "v=spf1 a mx include:_spf.google.com include:sendgrid.net include:mail.zendesk.com ~all include:_netblocks.google.com include:_netblocks2.google.com include:_netblocks3.google.com"`
